### PR TITLE
Fix some type mismatches, reported as linker errors by MSVC

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -108,7 +108,7 @@ int memfd;
 #endif
 #endif
 
-uint32 EventCycles = 128;
+int32 EventCycles = 128;
 
 // CPU overclock factor (or 0 if disabled)
 int32_t psx_overclock_factor = 0;

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -53,7 +53,7 @@ retro_input_state_t dbg_input_state_cb = 0;
 #endif /* HAVE_LIGHTREC */
 
 //Fast Save States exclude string labels from variables in the savestate, and are at least 20% faster.
-extern bool FastSaveStates;
+extern "C" uint8_t FastSaveStates;
 const int DEFAULT_STATE_SIZE = 16 * 1024 * 1024;
 
 static bool libretro_supports_bitmasks = false;

--- a/mednafen/state.c
+++ b/mednafen/state.c
@@ -37,7 +37,7 @@ int StateAction(StateMem *sm, int load, int data_only);
  * variables in the savestate, and are at least 20% faster.
  * Only used for internal savestates which will not be written to a file. */
 
-bool FastSaveStates = false;
+uint8_t FastSaveStates = false;
 
 static INLINE void MDFN_en32lsb_(uint8_t *buf, uint32_t morp)
 {


### PR DESCRIPTION
It's surprising these slipped by the linker for gcc/linux. I assume because the target is an `so` and the types of some references are not strictly checked in that situation.

Especially interesting is the bool reference in C++, which apparently worked despite C++ name mangling which is typically present on such types. (C++ standard imposes no standard on name mangling, so it's possible to have one compiler mangle the name and another to happenstance into matching the C language's unmangled exported symbol).